### PR TITLE
Fix extra bindings the the Mac's baseKeymap

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -609,11 +609,11 @@ let baseKeymap = {
 if (mac) {
   let extra = {
     "Ctrl-h": baseKeymap["Backspace"],
-    "Alt-Backspace": baseKeymap["Cmd-Backspace"],
+    "Alt-Backspace": baseKeymap["Mod-Backspace"],
     "Ctrl-d": baseKeymap["Delete"],
-    "Ctrl-Alt-Backspace": baseKeymap["Cmd-Delete"],
-    "Alt-Delete": baseKeymap["Cmd-Delete"],
-    "Alt-d": baseKeymap["Cmd-Delete"]
+    "Ctrl-Alt-Backspace": baseKeymap["Mod-Delete"],
+    "Alt-Delete": baseKeymap["Mod-Delete"],
+    "Alt-d": baseKeymap["Mod-Delete"]
   }
   for (let prop in extra) baseKeymap[prop] = extra[prop]
 }


### PR DESCRIPTION
The extras were trying to obtain their commands by reading from `baseKeymap` using the `Cmd-*` keys, which aren't there.