### PR TITLE
Bind Enter to splitBlockKeepMarks instead of splitBlock

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -507,7 +507,7 @@ exports.chainCommands = chainCommands
 // * **Mod-BracketLeft** to `lift`
 // * **Escape** to `selectParentNode`
 let baseKeymap = {
-  "Enter": chainCommands(newlineInCode, createParagraphNear, liftEmptyBlock, splitBlock),
+  "Enter": chainCommands(newlineInCode, createParagraphNear, liftEmptyBlock, splitBlockKeepMarks),
   "Mod-Enter": exitCode,
 
   "Backspace": chainCommands(deleteSelection, joinBackward),


### PR DESCRIPTION
As it is by far the more common situation in wysiwyg editors that marks persist after pressing enter, it makes sense for this to be the default in ProseMirror. A keymap can be used to revert Enter to use splitBlock instead.