### PR TITLE
Avoid deleting block-level atoms with backspace

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -52,8 +52,8 @@ export function joinBackward(state, dispatch, view) {
     return true
   }
 
-  // If the node before is an atom, delete it
-  if (before.isAtom && $cut.depth == $cursor.depth - 1) {
+  // If the node before is an inline atom, delete it
+  if (before.isAtom && before.isInline && $cut.depth == $cursor.depth - 1) {
     if (dispatch) dispatch(state.tr.delete($cut.pos - before.nodeSize, $cut.pos).scrollIntoView())
     return true
   }


### PR DESCRIPTION
Pressing backspace at the start of a block which is after a block marked as an "atom" will delete the preceding block. This is undesirable, so this change prevents atomic blocks from being deleted with backspace (they will be selected, instead).

I'm not 100% sure of the side-effects of this change, so please advise if there might be a better alternative solution.