### PR TITLE
Remove extra argument.

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -319,7 +319,7 @@ export function splitBlock(state, dispatch) {
     if (can) {
       tr.split(tr.mapping.map($from.pos), 1, types)
       if (!atEnd && !$from.parentOffset && $from.parent.type != deflt &&
-          $from.node(-1).canReplace($from.index(-1), $from.indexAfter(-1), Fragment.from(deflt.create(), $from.parent)))
+          $from.node(-1).canReplace($from.index(-1), $from.indexAfter(-1), Fragment.from(deflt.create())))
         tr.setNodeMarkup(tr.mapping.map($from.before()), deflt)
     }
     dispatch(tr.scrollIntoView())


### PR DESCRIPTION
While working with TS noticed it complaining about small typo in `splitBlock` function.

Static method `from` in `Fragment` class accepts only one argument:
https://github.com/ProseMirror/prosemirror-model/blob/master/src/fragment.js#L256