### PR TITLE
Support spec.keepAdjacent in joinForwards and joinBackwards

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -385,6 +385,7 @@ function deleteBarrier(state, $cut, dispatch) {
 
   let canDelAfter = $cut.parent.canReplace($cut.index(), $cut.index() + 1)
   if (canDelAfter &&
+      !before.type.spec.keepAdjacent &&
       (conn = (match = before.contentMatchAt(before.childCount)).findWrapping(after.type)) &&
       match.matchType(conn[0] || after.type).validEnd) {
     if (dispatch) {


### PR DESCRIPTION
I don't expect this to be ready to merge - just starting the conversation.

Some questions:

Any good ideas for spec property name? I've gone with `keepAdjacent` but I don't love it.

Tests? I noticed there are no tests for the `isolating` spec property, so maybe you are OK without.

Perhaps the deleteBarrier behaviour should only be suppressed if both the before and after nodes have `keepAdjacent`. Right now, backspace only checks the before node, and delete the after node.

I assume a corresponding PR for prosemirror-model will be needed. It looks like this will only be to include the new spec property in the doc comment. Do you follow any protocol for keeping such things in sync across repos?
