### PR TITLE
Bind Ctrl-a and Ctrl-e on macOS

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -432,6 +432,32 @@ function deleteBarrier(state, $cut, dispatch) {
   return false
 }
 
+// :: (EditorState, ?(tr: Transaction)) → bool
+// Moves the cursor to the start of current text block.
+// This is a workaround for Chrome and Safari on macOS, where Ctrl-a
+// gets stuck at the edge of inline nodes.
+// See https://discuss.prosemirror.net/t/shortcut-ctrl-a-ctrl-e-dont-work-on-macos-with-inline-node/
+function selectTextblockStart(state, dispatch) {
+  let $from = state.selection.$from
+  if (!$from.parent.type.isTextblock) return false
+  if (dispatch) dispatch(state.tr.setSelection(TextSelection.create(state.doc, $from.start())))
+  return true
+}
+
+// :: (EditorState, ?(tr: Transaction)) → bool
+// Moves the cursor to the end of current text block.
+// This is a workaround for Chrome and Safari on macOS, where Ctrl-e
+// gets stuck at the edge of inline nodes.
+// See https://discuss.prosemirror.net/t/shortcut-ctrl-a-ctrl-e-dont-work-on-macos-with-inline-node/
+function selectTextblockEnd(state, dispatch) {
+  let $to = state.selection.$to
+  if (!$to.parent.type.isTextblock) return false
+  if (dispatch) dispatch(state.tr.setSelection(TextSelection.create(state.doc, $to.end())))
+  return true
+}
+
+export { selectTextblockStart as __selectTextblockStart, selectTextblockEnd as __selectTextblockEnd }
+
 // Parameterized commands
 
 // :: (NodeType, ?Object) → (state: EditorState, dispatch: ?(tr: Transaction)) → bool
@@ -626,7 +652,9 @@ export let macBaseKeymap = {
   "Ctrl-d": pcBaseKeymap["Delete"],
   "Ctrl-Alt-Backspace": pcBaseKeymap["Mod-Delete"],
   "Alt-Delete": pcBaseKeymap["Mod-Delete"],
-  "Alt-d": pcBaseKeymap["Mod-Delete"]
+  "Alt-d": pcBaseKeymap["Mod-Delete"],
+  'Ctrl-a': selectTextblockStart,
+  'Ctrl-e': selectTextblockEnd
 }
 for (let key in pcBaseKeymap) macBaseKeymap[key] = pcBaseKeymap[key]
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -432,7 +432,7 @@ function deleteBarrier(state, $cut, dispatch) {
   return false
 }
 
-// :: (EditorState, ?(tr: Transaction)) → bool
+// : (EditorState, ?(tr: Transaction)) → bool
 // Moves the cursor to the start of current text block.
 // This is a workaround for Chrome and Safari on macOS, where Ctrl-a
 // gets stuck at the edge of inline nodes.
@@ -444,7 +444,7 @@ function selectTextblockStart(state, dispatch) {
   return true
 }
 
-// :: (EditorState, ?(tr: Transaction)) → bool
+// : (EditorState, ?(tr: Transaction)) → bool
 // Moves the cursor to the end of current text block.
 // This is a workaround for Chrome and Safari on macOS, where Ctrl-e
 // gets stuck at the edge of inline nodes.

--- a/test/test-commands.js
+++ b/test/test-commands.js
@@ -5,6 +5,7 @@ const ist = require("ist")
 
 const {joinBackward, selectNodeBackward, joinForward, selectNodeForward, deleteSelection, joinUp, joinDown, lift,
        wrapIn, splitBlock, splitBlockKeepMarks, liftEmptyBlock, createParagraphNear, setBlockType,
+       __selectTextblockStart: selectTextblockStart,  __selectTextblockEnd: selectTextblockEnd,
        selectParentNode, autoJoin, toggleMark} = require("..")
 
 function selFor(doc) {
@@ -518,5 +519,31 @@ describe("toggleMark", () => {
   it("doesn't skip whitespace-only selections", () => {
     apply(doc(p("one<a> <b>two")), toggleEm,
           doc(p("one", em(" "), "two")))
+  })
+})
+
+describe('selectTextblockStart and selectTextblockEnd', () => {
+  it("can move the cursor when the selection is empty", () => {
+    apply(doc(p("one <a>two")), selectTextblockStart,
+          doc(p("<a>one two")))
+
+    apply(doc(p("one <a>two")), selectTextblockEnd,
+          doc(p("one two<a>")))
+  })
+
+  it("can move the cursor when the selection is not empty", () => {
+    apply(doc(p("one <a>two<b>")), selectTextblockStart,
+          doc(p("<a>one two")))
+
+    apply(doc(p("one <a>two<b>")), selectTextblockEnd,
+          doc(p("one two<a>")))
+  })
+
+  it("can move the cursor when the cursor across multiple text blocks", () => {
+    apply(doc(p("one <a>two"), p('three<b> four')), selectTextblockStart,
+          doc(p("<a>one two"), p('three four')))
+
+    apply(doc(p("one <a>two"), p('three<b> four')), selectTextblockEnd,
+          doc(p("one two"), p('three four<a>')))
   })
 })


### PR DESCRIPTION
FIX: Add a workaround for a bug on macOS where Ctrl-a and
Ctrl-e getting stuck at the edge of inline nodes.

Issue https://discuss.prosemirror.net/t/shortcut-ctrl-a-ctrl-e-dont-work-on-macos-with-inline-node

--- 

- I didn't bind these two commands to `Home` and `End` in `pcBaseKeymap` because the browsers on Windows don't seem to have this bug. 
  (Test environment: Windows Server 2019 version 1809, Chrome 97, Firefox 96)
- I'm not sure if these commands should be exported as public APIs, so I only exported them for testing. 
