### PR TITLE
Fix toggleMark bug for selections with depth zero

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -485,7 +485,7 @@ export function setBlockType(nodeType: NodeType, attrs: Attrs | null = null): Co
 function markApplies(doc: Node, ranges: readonly SelectionRange[], type: MarkType) {
   for (let i = 0; i < ranges.length; i++) {
     let {$from, $to} = ranges[i]
-    let can = $from.depth == 0 ? doc.type.allowsMarkType(type) : false
+    let can = $from.depth == 0 ? doc.inlineContent && doc.type.allowsMarkType(type) : false
     doc.nodesBetween($from.pos, $to.pos, node => {
       if (can) return false
       can = node.inlineContent && node.type.allowsMarkType(type)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -488,7 +488,10 @@ function markApplies(doc: Node, ranges: readonly SelectionRange[], type: MarkTyp
     let can = $from.depth == 0 ? doc.inlineContent && doc.type.allowsMarkType(type) : false
     doc.nodesBetween($from.pos, $to.pos, node => {
       if (can) return false
-      can = node.inlineContent && node.type.allowsMarkType(type)
+      if (node.inlineContent && node.type.allowsMarkType(type)) {
+        can = true;
+        return false;
+      }
     })
     if (can) return true
   }


### PR DESCRIPTION
When a selection range starts at depth zero, allow toggleMark commands
to succeed only if the top node both allows the mark and has inline
content. These restrictions align with the restrictions for the command
to succeed on other selections, fixing an edge case that 5692407 did not
catch.