### PR TITLE
toggleMark: append mark unless it is already present throughout the selection

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -591,10 +591,15 @@ export function toggleMark(markType: MarkType, attrs: Attrs | null = null): Comm
         else
           dispatch(state.tr.addStoredMark(markType.create(attrs)))
       } else {
-        let has = false, tr = state.tr
+        let has = false, entireSelHas = false, tr = state.tr
         for (let i = 0; !has && i < ranges.length; i++) {
           let {$from, $to} = ranges[i]
           has = state.doc.rangeHasMark($from.pos, $to.pos, markType)
+          entireSelHas = has
+          // its admittedly cumbersome to verify mark absence one char at a time
+          for (let j = $from.pos; has && has === entireSelHas && j < $to.pos; j++) {
+            entireSelHas = state.doc.rangeHasMark(j, j + 1, markType)
+          }
         }
         for (let i = 0; i < ranges.length; i++) {
           let {$from, $to} = ranges[i]


### PR DESCRIPTION
greetings! 👋 

we've had a few users report that they expect a mark to be toggled _on_ when only a subset of their selection is already similarly marked.

ie: "something **important**!" > "**something important!**"

i checked a few other text editors and the current behavior definitely appears to be an aberration.

if this isn't a change you're interested in landing, no offense taken. if it _is_ something you're willing to entertain, i'm happy polish up this PR by updating the inline documentation and taking a crack at writing a new unit test to verify the expected behavior.