### PR TITLE
add failing test to highlight removeWhenPresent misbehavior

### DIFF
--- a/test/test-commands.ts
+++ b/test/test-commands.ts
@@ -590,6 +590,18 @@ describe("toggleMark", () => {
     apply(doc(p(em("o<a>ne two"), "  <b>")), toggleEm2,
           doc(p(em("o"), "ne two  ")))
   })
+
+  // passing
+  it("can remove marks with trailing space and adjacent unmarked text when remove-when-present is off", () => {
+    apply(doc(p(em("<a>one two "), "<b>three")), toggleEm2,
+          doc(p("one two three")))
+  })
+
+  // failing
+  it("can add a mark to trailing space with adjacent unmarked text when remove-when-present is off", () => {
+   apply(doc(p(em("<a>one two"), " <b>three")), toggleEm2,
+         doc(p(em("one two "), "three")))
+  })
 })
 
 describe('selectTextblockStart and selectTextblockEnd', () => {


### PR DESCRIPTION
hello again! 👋 

in testing your patches from #17 i spotted another edge case that makes it impossible to successfully toggle marks.

1. add a mark to a single word within a sentence.
1. create a selection that includes the word and subsequent whitespace
1. attempt to toggle the mark again.

w/ `{removeWhenPresent:false}` i would expect the initial execution of the command to append the mark to the newly selected whitespace and the second call to remove the mark from the entire selection.

in actuality, the mark cannot be added to the trailing whitespace, and hence cannot be removed from the actual word.