### PR TITLE
Correct some links in the JSDoc comments

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -74,7 +74,7 @@ export const joinBackward: Command = (state, dispatch, view) => {
   return false
 }
 
-/// A more limited form of [`joinBackward`]($commands.joinBackward)
+/// A more limited form of [`joinBackward`](#commands.joinBackward)
 /// that only tries to join the current textblock to the one before
 /// it, if the cursor is at the start of a textblock.
 export const joinTextblockBackward: Command = (state, dispatch, view) => {
@@ -84,7 +84,7 @@ export const joinTextblockBackward: Command = (state, dispatch, view) => {
   return $cut ? joinTextblocksAround(state, $cut, dispatch) : false
 }
 
-/// A more limited form of [`joinForward`]($commands.joinForward)
+/// A more limited form of [`joinForward`](#commands.joinForward)
 /// that only tries to join the current textblock to the one after
 /// it, if the cursor is at the end of a textblock.
 export const joinTextblockForward: Command = (state, dispatch, view) => {


### PR DESCRIPTION
Fix some links in the docs, shown below:

<img width="1054" alt="image" src="https://github.com/user-attachments/assets/7605cdaf-f5d5-4c46-b1b1-cba97446a0b7" />


